### PR TITLE
feat: add support for uploading additional files created by commands

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -45,6 +45,7 @@ Common diff flags for grading:
 | `--upload-config` | Configuration as JSON | `'{"endpoint": "localhost:9000"}'` |
 | `--upload-config-kv` | Config key=value pairs (repeatable) | `"bucket=results"` |
 | `--upload-config-file` | Path to config JSON file | `upload-config.json` |
+| `--upload-files` | Additional files to upload (repeatable) | `"output.bin"` or `"local.txt:remote/path.txt"` |
 
 ### Webhook Configuration Flags
 
@@ -147,6 +148,30 @@ Optional fields:
 - `prefix`: Path prefix for uploaded files
 - `use_ssl`: Enable SSL/TLS (default: true for S3, false for localhost)
 - `region`: AWS region (for S3)
+
+#### Additional Files Upload
+
+The `--upload-files` flag allows uploading files created by your command alongside the standard output/stderr files.
+
+Format: `local_path[:remote_path]`
+- If remote path is omitted, the local path is used as the remote path
+- Can be specified multiple times for multiple files
+- Files are validated to exist after command execution
+- All uploads respect the configured prefix
+
+Examples:
+```bash
+# Upload with same local/remote path
+--upload-files "output.bin"
+
+# Upload with different remote path  
+--upload-files "local.txt:remote/path.txt"
+
+# Multiple files
+--upload-files "result1.csv" \
+--upload-files "result2.csv:data/result2.csv" \
+--upload-files "summary.json:reports/summary.json"
+```
 
 Example configuration:
 ```json

--- a/cmd/config/types.go
+++ b/cmd/config/types.go
@@ -11,10 +11,11 @@ type ContextConfig struct {
 
 // UploadConfig holds upload-related flags
 type UploadConfig struct {
-	Provider   string
-	Config     string
-	ConfigKV   []string
-	ConfigFile string
+	Provider    string
+	Config      string
+	ConfigKV    []string
+	ConfigFile  string
+	UploadFiles []string // Additional files to upload (format: local[:remote])
 }
 
 // CommonFlags holds commonly used flags across commands

--- a/cmd/helpers/flags.go
+++ b/cmd/helpers/flags.go
@@ -18,6 +18,7 @@ func SetupUploadFlags(cmd *cobra.Command, cfg *config.UploadConfig) {
 	cmd.Flags().StringVar(&cfg.Config, "upload-config", "", "Upload configuration as JSON string")
 	cmd.Flags().StringArrayVar(&cfg.ConfigKV, "upload-config-kv", nil, "Upload config key=value pairs (can be used multiple times)")
 	cmd.Flags().StringVar(&cfg.ConfigFile, "upload-config-file", "", "Path to JSON file containing upload configuration")
+	cmd.Flags().StringArrayVar(&cfg.UploadFiles, "upload-files", nil, "Additional files to upload (format: local[:remote], can be used multiple times)")
 }
 
 // SetupCommonFlags adds commonly used flags to a command


### PR DESCRIPTION
- Added --upload-files flag to specify additional files to upload
- Format: local[:remote] where remote path is optional (defaults to local)
- Supports multiple files via repeated --upload-files flags
- Files are validated to exist after command execution
- All uploads respect the configured prefix
- Enhanced dry-run output to show standard vs additional files
- Updated PrintUploadInfo to display additional files
- Integrated with both run and diff commands
- Added comprehensive documentation and examples

This feature is essential for commands that produce output files beyond stdout/stderr, such as compilers generating binaries or data processing scripts creating reports and artifacts.