### PR TITLE
feat: include /dev in read-write paths and /proc/self/fd in read-only paths for Landlock sandbox

### DIFF
--- a/internal/sandbox/sandbox_linux.go
+++ b/internal/sandbox/sandbox_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ApplySandbox applies Landlock filesystem restrictions.
-// Read-only: /usr, /bin, /lib, /lib64, /etc (ignored if missing).
+// Read-only: /usr, /bin, /lib, /lib64, /etc (ignored if missing), /proc/self/fd.
 // Read-write: /output, /tmp, /dev, and the given work directory.
 func ApplySandbox(workDir string) error {
 	if workDir == "" {
@@ -18,6 +18,7 @@ func ApplySandbox(workDir string) error {
 
 	err := landlock.V5.BestEffort().RestrictPaths(
 		landlock.RODirs("/usr", "/bin", "/lib", "/lib64", "/etc").IgnoreIfMissing(),
+		landlock.RODirs("/proc/self/fd"),
 		landlock.RWDirs("/output", "/tmp", "/dev", workDir),
 	)
 	if err != nil {

--- a/internal/sandbox/sandbox_linux.go
+++ b/internal/sandbox/sandbox_linux.go
@@ -10,7 +10,7 @@ import (
 
 // ApplySandbox applies Landlock filesystem restrictions.
 // Read-only: /usr, /bin, /lib, /lib64, /etc (ignored if missing).
-// Read-write: /output, /tmp, and the given workDir.
+// Read-write: /output, /tmp, /dev, and the given work directory.
 func ApplySandbox(workDir string) error {
 	if workDir == "" {
 		return fmt.Errorf("sandbox: workDir must not be empty")
@@ -18,7 +18,7 @@ func ApplySandbox(workDir string) error {
 
 	err := landlock.V5.BestEffort().RestrictPaths(
 		landlock.RODirs("/usr", "/bin", "/lib", "/lib64", "/etc").IgnoreIfMissing(),
-		landlock.RWDirs("/output", "/tmp", workDir),
+		landlock.RWDirs("/output", "/tmp", "/dev", workDir),
 	)
 	if err != nil {
 		return fmt.Errorf("sandbox: landlock restrict paths: %w", err)


### PR DESCRIPTION
This pull request updates the Landlock sandbox configuration in `sandbox_linux.go` to refine which directories are accessible and with what permissions. The main goal is to improve security and compatibility by adjusting the set of allowed read-only and read-write directories.

**Sandbox configuration changes:**

* Added `/proc/self/fd` to the list of read-only directories to improve compatibility with processes that need to access file descriptors.
* Added `/dev` to the list of read-write directories, allowing sandboxed processes to interact with device files as needed.