### PR TITLE
fix(agent): pin GOMAXPROCS to the CPU quota; keep heartbeats alive through uploads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	go.temporal.io/sdk v1.30.0
+	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/net v0.41.0
 	golang.org/x/sys v0.40.0
 )

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJ
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
@@ -116,6 +118,8 @@ go.temporal.io/api v1.40.0/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis
 go.temporal.io/sdk v1.30.0 h1:7jzSFZYk+tQ2kIYEP+dvrM7AW9EsCEP52JHCjVGuwbI=
 go.temporal.io/sdk v1.30.0/go.mod h1:Pv45F/fVDgWKx+jhix5t/dGgqROVaI+VjPLd3CHWqq0=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=

--- a/internal/agent/activities.go
+++ b/internal/agent/activities.go
@@ -23,8 +23,22 @@ import (
 )
 
 // heartbeatInterval is how often the agent records an activity heartbeat
-// while a child command is running.
-const heartbeatInterval = 10 * time.Second
+// while a child command is running. NOTE the wire reality (core backend/12):
+// the Temporal SDK BATCHES these — the server actually receives one heartbeat
+// per min(0.8×HeartbeatTimeout, 60s) window; this tick only guarantees a
+// fresh heartbeat is queued for every send window. A var, not a const, so
+// the upload-phase heartbeat regression test can shrink it.
+var heartbeatInterval = 10 * time.Second
+
+// heartbeatTickDelayWarn is the tick-servicing delay above which the agent
+// warns about runtime CPU starvation. Normal servicing is µs–ms; delays of
+// seconds mean the Go runtime is not getting CPU onto its timers (the core
+// backend/12 pathology — at its worst this delays the SDK's batched SEND
+// timer past the server's margin and a live container is declared dead).
+// After the HeartbeatTimeout widening those stalls no longer fail runs, so
+// this WARN is the surviving observability for the failure class: it turns
+// every starvation event into a log line instead of silence.
+const heartbeatTickDelayWarn = 3 * time.Second
 
 // Activities implements the two contract activities the agent registers
 // on its per-run task queue.
@@ -196,8 +210,14 @@ func (a *Activities) RunExec(ctx context.Context, in contract.RunExecInput) (con
 		return infraFail(fmt.Errorf("failed to spawn command: %w", err))
 	}
 
-	// Heartbeat while the child runs so core's heartbeat timeout can
-	// detect a dead container mid-exec.
+	// Heartbeat while the exec RUNS AND while its captures upload, so core's
+	// heartbeat timeout only ever detects a dead container — never a live
+	// one still doing post-exec work. Stopped via defer (not inline before
+	// the upload phase): a timed-out exec finishes its window with the wire
+	// heartbeat cadence already near its edge, and the kill + capture
+	// copies + three object-store uploads that follow would otherwise run
+	// heartbeat-dark under exactly the starved conditions that delayed the
+	// exec (core backend/12).
 	hbStop := make(chan struct{})
 	var hbWG sync.WaitGroup
 	hbWG.Add(1)
@@ -209,10 +229,28 @@ func (a *Activities) RunExec(ctx context.Context, in contract.RunExecInput) (con
 			select {
 			case <-hbStop:
 				return
-			case <-ticker.C:
+			case tick := <-ticker.C:
+				// tick carries the SCHEDULED fire time (the 1.23+ timer
+				// rework backdates the stamp), so time.Since(tick) is this
+				// tick's true servicing delay. Two causes can produce it:
+				// runtime CPU starvation (the backend/12 pathology), or the
+				// previous RecordHeartbeat blocking this goroutine on a slow
+				// wire send (the SDK sends synchronously when no batch
+				// window is open). Both are worth a WARN; don't assume
+				// which from the message alone. During a multi-tick stall
+				// only the oldest buffered tick is delivered, so one WARN
+				// may stand for several skipped windows.
+				if delay := time.Since(tick); delay > heartbeatTickDelayWarn {
+					logger.Warn("heartbeat tick serviced late (runtime CPU starvation or blocked heartbeat send)",
+						"delay", delay.String(), "stage", in.Stage, "scenario", in.ScenarioCode)
+				}
 				activity.RecordHeartbeat(ctx)
 			}
 		}
+	}()
+	defer func() {
+		close(hbStop)
+		hbWG.Wait()
 	}()
 
 	waitCh := make(chan error, 1)
@@ -231,17 +269,14 @@ func (a *Activities) RunExec(ctx context.Context, in contract.RunExecInput) (con
 		waitErr = <-waitCh
 	case <-ctx.Done():
 		// Activity cancelled/timed out by core: kill the child and
-		// surface the cancellation as an activity error.
+		// surface the cancellation as an activity error. (The deferred
+		// heartbeat stop runs on return.)
 		timer.Stop()
 		killProcessGroup(cmd)
 		<-waitCh
-		close(hbStop)
-		hbWG.Wait()
 		finish()
 		return contract.ExecResult{}, ctx.Err()
 	}
-	close(hbStop)
-	hbWG.Wait()
 	finish()
 
 	var infraErrs []string

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,11 +2,14 @@ package agent
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"runtime"
 
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/zinc-sig/ghost/internal/agent/contract"
 )
@@ -15,6 +18,45 @@ import (
 // two contract activities until interrupted (SIGTERM/SIGINT drain the
 // worker gracefully).
 func Run(cfg *Config) error {
+	// Pin GOMAXPROCS to the container's cgroup CPU quota (core backend/12
+	// root-cause fix). Grading containers run with a 1-CPU bandwidth quota
+	// while the node has ~16 cores; Go 1.24 sizes GOMAXPROCS from
+	// runtime.NumCPU() (the quota does not lower nproc), so the runtime
+	// carries 16 Ps' worth of scheduling/timer machinery on a sliver of one
+	// CPU shared with CPU-pegging student processes. Under CFS bandwidth
+	// throttling that starves the runtime's TIMER SERVICING: the Temporal
+	// SDK's batched heartbeat-send timer (one wire send per ~48-60s window)
+	// fires late, the send is never attempted inside the server's margin,
+	// and a LIVE container is declared dead.
+	//
+	// The ceil-rounding + floor-of-2 below deliberately REPRODUCES Go
+	// 1.25+'s native container-aware formula, min(NumCPU, max(ceil(quota),
+	// 2)) (runtime/cgroup_linux.go) — GOMAXPROCS=2 for the 1-CPU grading
+	// quota. Upstream floors at 2 on purpose (GC/runtime progress
+	// headroom), and matching it keeps a future `go 1.25+` go.mod bump
+	// behavior-neutral. NOTE the native mechanism is gated on the go.mod
+	// LANGUAGE VERSION, not the toolchain, and an explicit GOMAXPROCS pin
+	// disables its dynamic quota tracking — so this call is NOT redundant
+	// until the go directive moves to 1.25+ AND this is removed together.
+	// A pre-set GOMAXPROCS env var (e.g. baked into a course environment
+	// image) wins over this pin by design; the boot line below exposes the
+	// effective value either way. Failure to detect the quota is non-fatal
+	// — we log and run with the default, exactly as before this fix.
+	if _, err := maxprocs.Set(
+		maxprocs.Logger(func(format string, args ...interface{}) {
+			fmt.Fprintf(os.Stderr, "ghost agent: "+format+"\n", args...)
+		}),
+		maxprocs.RoundQuotaFunc(func(q float64) int { return int(math.Ceil(q)) }),
+		maxprocs.Min(2),
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "ghost agent: maxprocs: %v (continuing with default GOMAXPROCS)\n", err)
+	}
+	// Boot forensics: one line that answers "what was the runtime actually
+	// configured as" for every future run (core backend/12 taught us this
+	// is the first question of any heartbeat investigation).
+	fmt.Fprintf(os.Stderr, "ghost agent: runtime GOMAXPROCS=%d NumCPU=%d\n",
+		runtime.GOMAXPROCS(0), runtime.NumCPU())
+
 	if err := os.MkdirAll(cfg.Workdir, 0o755); err != nil {
 		return fmt.Errorf("agent: failed to create workspace %s: %w", cfg.Workdir, err)
 	}

--- a/internal/agent/heartbeat_upload_test.go
+++ b/internal/agent/heartbeat_upload_test.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+
+	"github.com/zinc-sig/ghost/internal/agent/contract"
+)
+
+// slowUploadStore wraps fakeStore with a per-upload delay, modeling a slow
+// object-storage backend during the post-exec upload phase.
+type slowUploadStore struct {
+	*fakeStore
+	delay time.Duration
+}
+
+func (s *slowUploadStore) UploadFile(ctx context.Context, bucket, key, path string) error {
+	time.Sleep(s.delay)
+	return s.fakeStore.UploadFile(ctx, bucket, key, path)
+}
+
+// TestRunExec_HeartbeatsThroughUploadPhase pins the backend/12 upload-window
+// fix: heartbeats must keep flowing WHILE the post-exec capture uploads run,
+// not stop when the child exits. Before the fix the heartbeat goroutine was
+// closed before the uploads, so a slow storage backend left the activity
+// heartbeat-dark exactly when the exec had already consumed its window —
+// presenting as a spurious server-side heartbeat timeout on a live container.
+//
+// Mechanism: a near-instant exec (so the exec phase contributes ~no ticks)
+// followed by two slow uploads (stdout + stderr, 400ms each) with a 50ms
+// tick. Any substantial number of observed heartbeats can therefore only
+// have been recorded during the upload phase.
+func TestRunExec_HeartbeatsThroughUploadPhase(t *testing.T) {
+	origInterval := heartbeatInterval
+	heartbeatInterval = 150 * time.Millisecond
+	defer func() { heartbeatInterval = origInterval }()
+
+	cfg := newTestConfig(t)
+	store := &slowUploadStore{fakeStore: newFakeStore(), delay: 500 * time.Millisecond}
+	env := newActivityEnv(t, cfg, store)
+
+	var beats atomic.Int64
+	env.SetOnActivityHeartbeatListener(func(_ *activity.Info, _ converter.EncodedValues) {
+		beats.Add(1)
+	})
+
+	input := contract.RunExecInput{
+		ProtocolVersion: contract.ProtocolVersion,
+		Stage:           "test",
+		ScenarioCode:    "q1",
+		Spec: contract.ExecSpec{
+			Command: "/bin/echo",
+			Args:    []string{"hb"},
+			Workdir: ".",
+		},
+		StdioUpload: contract.StdioUploadSpec{Bucket: "runs", KeyPrefix: "55/test/q1"},
+	}
+	res := execRun(t, env, input)
+	if res.ExitCode == nil || *res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %v, want 0 (error: %q)", res.ExitCode, res.Error)
+	}
+
+	// WHY ">= 1", not a tick count: the SDK BATCHES RecordHeartbeat calls
+	// (the exact mechanism backend/12 turned on) — the test env's invoker
+	// uses the default 30s throttle regardless of worker options, so the
+	// listener observes WIRE SENDS, not ticks: the first tick sends
+	// immediately, every later tick coalesces into a window that outlives
+	// the test. The timing makes one send fully discriminating: the echo
+	// exec finishes in a few ms, far inside the 150ms first tick — so
+	// WITHOUT the defer fix the ticker goroutine is closed before it ever
+	// fires and the listener sees exactly 0 sends; WITH the fix the first
+	// tick lands ~150ms into the ~1s upload phase and sends. Any recorded
+	// heartbeat therefore proves ticking continued through the uploads.
+	if got := beats.Load(); got < 1 {
+		t.Fatalf("recorded %d heartbeats — heartbeats did not continue through the upload phase", got)
+	}
+}


### PR DESCRIPTION
# fix(agent): pin GOMAXPROCS to the CPU quota; keep heartbeats alive through uploads

## MERGE = RELEASE

`release.yml` auto-cuts **v0.0.19** on push to main. Merging this PR publishes the
release binary; the staging rebake (default grading image + template 4, with the
backend/14 reference-solution drift guard) and the d57 field experiment are prepped by
the deployment side and gated separately.

## Why (core backend/12)

A submission whose code loops kills its entire grading run with a Temporal heartbeat
timeout at ~2/3 per-run rate on an idle cluster — a LIVE container declared dead, and the
failed run then poisons the score of record (core backend/11). Instrumented staging repro
(evidence archived at core `trial-survey-issues/evidence/repro-d57-20260817/`) localized
the failure to **ghost's heartbeat send path**, by exclusion:

- the server's `RecordActivityTaskHeartbeat` request counter stays FLAT through the blip
  (the send never arrives);
- the TCP connection stays ESTABLISHED with `tx_queue=0`, zero retransmits (the write is
  never issued — network/dind exonerated);
- a mid-stall goroutine dump is quiescent: GC idle, nothing runnable, the SDK's batched
  send goroutine asleep on its unserviced ~48s timer (GC exonerated);
- ~19% pass rate excludes a lost/never-rearmed timer (that would fail 100%).

Wire reality that makes the stall fatal: the SDK BATCHES `RecordHeartbeat` calls into one
send per `min(0.8 x HeartbeatTimeout, 60s)` window — a rigid measured 48.0s cadence at
core's (old) HT=60s, leaving a 12s margin any send-path stall can blow.

## What

1. **GOMAXPROCS derived from the cgroup quota** (`go.uber.org/automaxprocs`, applied at
   agent boot only — CLI/exec-child paths untouched). Grading containers run a 1-CPU
   bandwidth quota on ~16-core nodes; Go 1.24 sizes GOMAXPROCS from nproc, so the runtime
   carried 16 Ps' worth of scheduler/timer machinery on a sliver of one CPU shared with
   CPU-pegging student processes. The pin **deliberately reproduces Go 1.25+'s native
   container-aware formula** `min(NumCPU, max(ceil(quota), 2))` -> **GOMAXPROCS=2** here
   (upstream floors at 2 for GC/runtime-progress headroom; matching it keeps a future
   `go 1.25+` go.mod bump behavior-neutral). Non-fatal on detection failure; a pre-set
   `GOMAXPROCS` env var (e.g. baked into a course image) wins by design; the boot line
   exposes the effective value either way.
2. **Heartbeat goroutine stopped via `defer`, AFTER the post-kill capture copies and
   stdio uploads.** Previously it was closed before the upload phase, which therefore ran
   heartbeat-dark under exactly the conditions that had already delayed the exec.
3. **Observability for the failure class** (it becomes silent once core widens
   HeartbeatTimeout to 180s — companion core PR): a boot line logs effective
   GOMAXPROCS/NumCPU, and any heartbeat tick serviced >3s late logs a WARN with the
   measured delay (the ticker channel carries the scheduled fire time, so
   `time.Since(tick)` is the true servicing delay). Every future stall becomes a log line
   instead of a dead run or silence.

## Honest scope: what is proven vs. suspected

- **Proven**: the stall lives in ghost's send path (the exclusion chain above), and the
  upload phase was heartbeat-dark (regression test below).
- **Suspected, not proven**: that the GOMAXPROCS mismatch is the CAUSE. A three-cell lab
  falsification (measured 48s one-shot timers + 10s ticker + allocation, 4 pegging
  children, `--cpus=1`, including a cell built with the exact deployed go1.24.13
  toolchain at GOMAXPROCS=16) produced max ~1ms timer delays — the mismatch is at most an
  AMPLIFIER. Remaining suspects for the real trigger: memory pressure (1GiB limit +
  numpy/pandas children) and the real SDK/gRPC send path. The GOMAXPROCS pin ships
  regardless because upstream Go made quota-aware GOMAXPROCS the language default — it is
  correct hygiene independent of causality.
- **The rebaked field run is the decisive, self-instrumenting experiment** (decision tree
  recorded in core backend/12): failures stop -> amplifier vindicated; failures persist
  WITH late-tick WARNs -> starvation real but GOMAXPROCS-independent; failures persist
  WITHOUT WARNs -> the stall is below the app tick (SDK invoker / gRPC write path).

## Review trail

Two independent adversarial reviews (all findings applied):
- GOMAXPROCS=1-vs-2 divergence from upstream caught and resolved by matching the native
  formula, with the (previously false) "no-op on Go 1.25+" comment corrected — the native
  mechanism keys off the go.mod LANGUAGE VERSION, not the toolchain, and an explicit pin
  disables its dynamic tracking, so this call stays load-bearing until the directive
  moves to 1.25+ and the pin is removed together.
- WARN wording fixed to name both possible causes (runtime starvation OR a blocked
  synchronous first-window send).
- automaxprocs moved from indirect to direct in go.mod (`go mod tidy`).
- automaxprocs behavior verified from its source for this exact topology: cgroupns
  private (set by core's `docker.go`), cgroup v2, `cpu.max = 100000 100000`; the pin
  cannot leak to the student child (runtime call, not env; child execve's away).

## Tests

- New `TestRunExec_HeartbeatsThroughUploadPhase` — **mutation-verified**: reverting the
  defer fix fails the test; the fix passes (x3, race-clean). The test documents why one
  delivered heartbeat is the discriminating assertion (the SDK's own batching coalesces
  the rest — the very mechanism this whole incident turned on).
- Full suite: 10/10 packages, `go vet`, `gofmt` clean.
- Field acceptance (deployment side, post-rebake): d57 re-grades with failure rate ~0,
  boot line shows `GOMAXPROCS=2`, tick-delay WARNs absent (or present and measured —
  every branch is informative per the decision tree).

## Companion / sequencing

- Core PR `fix/exec-heartbeat-defense-margin` (HT 60s->180s, defense-in-depth) merges
  AFTER this ships and the field run completes, so the field signal stays clean at the
  live HT=60s.
- Deferred to the next scheduled ghost cycle: Go toolchain + go.mod directive bump to
  1.25/1.26 (1.24 is out of its support window) batched with the SDK v1.30.0 bump; the
  pin can be retired then.
- backend/14 (`reghost` overlay op) remains the future fix for agent-only rebakes.

Refs core backend/12; evidence: core `trial-survey-issues/evidence/repro-d57-20260817/`.
